### PR TITLE
chore(*): upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 embedded-storage = "0.2.0"
 embedded-hal = { version = "=1.0.0-alpha.6" }
-stm32l4xx-hal = { git = "https://github.com/BlackbirdHQ/stm32l4xx-hal", branch = "factbird-duo-1.3", features = [
+stm32l4xx-hal = { git = "https://github.com/BlackbirdHQ/stm32l4xx-hal", branch = "factbird-duo-1.4", features = [
     "stm32l475",
     "rt",
 ] }


### PR DESCRIPTION
This PR updates embedded-hal to use v1.0.0-alpha.6